### PR TITLE
fix: version sync and release workflow improvements

### DIFF
--- a/.github/workflows/publish_crates.yml
+++ b/.github/workflows/publish_crates.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
+    paths:
+      - .github/workflows/publish_crates.yml
 
 permissions:
   id-token: write # Required for OIDC
@@ -24,18 +27,6 @@ jobs:
           toolchain: ${{vars.RUST_TOOLCHAIN || 'stable'}}
       - name: Set up tree-sitter CLI
         uses: tree-sitter/setup-action/cli@v2
-      - name: Install dependencies
-        run: |-
-          if jq -e "$JQ_SCRIPT" package.json >/dev/null; then
-            npm i --ignore-scripts --omit peer --omit optional
-          fi
-        env:
-          JQ_SCRIPT: >-
-            .dependencies + .devDependencies |
-            with_entries(select(
-            (.key | startswith("tree-sitter-"))
-            and (.key != "tree-sitter-cli")
-            )) | length > 0
       - name: Regenerate parser
         run: |
           while read -r grammar_dir; do
@@ -43,12 +34,14 @@ jobs:
             tree-sitter generate
             popd > /dev/null
           done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
-        env:
-          TREE_SITTER_ABI_VERSION: 15
+      - name: Sync version from tree-sitter.json
+        run: yq -i ".package.version = \"$(jq -r .metadata.version tree-sitter.json)\"" Cargo.toml
+
       - name: Set up registry token
         id: auth
         uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish to crates.io
-        run: cargo publish
+        run: cargo publish --color=always --allow-dirty --verbose ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
+    paths:
+      - .github/workflows/publish_npm.yml
 
 permissions:
   id-token: write # Required for OIDC
@@ -22,21 +25,21 @@ jobs:
         with:
           cache: npm
           node-version: ${{vars.NODE_VERSION || '24'}}
+      - name: Set up tree-sitter CLI
+        uses: tree-sitter/setup-action/cli@v2
       - name: Install dependencies
         run: npm i --omit peer --omit optional
       - name: Regenerate parser
         run: |
           while read -r grammar_dir; do
             pushd "$grammar_dir"
-            npm x -- tree-sitter generate
+            tree-sitter generate
             popd > /dev/null
           done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
-        env:
-          TREE_SITTER_ABI_VERSION: 15
       - name: Build Wasm binaries
         run: |-
           while read -r grammar_dir; do
-            npm x -- tree-sitter build --wasm "$grammar_dir"
+            tree-sitter build --wasm "$grammar_dir"
           done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
       - name: Upload binaries
         uses: actions/upload-artifact@v6
@@ -65,6 +68,8 @@ jobs:
         with:
           cache: npm
           node-version: ${{vars.NODE_VERSION || '24'}}
+      - name: Set up tree-sitter CLI
+        uses: tree-sitter/setup-action/cli@v2
       - name: Install dependencies
         run: npm i --omit peer --omit optional
       - name: Regenerate parser
@@ -73,7 +78,7 @@ jobs:
           while read -r grammar_dir; do
             grammar_dir="${grammar_dir%$'\r'}"
             pushd "$grammar_dir"
-            npm x -- tree-sitter generate
+            tree-sitter generate
             popd > /dev/null
           done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
       - name: Build binary
@@ -112,5 +117,7 @@ jobs:
       - name: Move Wasm binaries to root
         continue-on-error: true
         run: mv -v prebuilds/*.wasm .
+      - name: Sync version from tree-sitter.json
+        run: npm version --no-git-tag-version "$(jq -r .metadata.version tree-sitter.json)"
       - name: Publish to npm
-        run: npm publish
+        run: npm publish ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -118,6 +118,7 @@ jobs:
         continue-on-error: true
         run: mv -v prebuilds/*.wasm .
       - name: Sync version from tree-sitter.json
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: npm version --no-git-tag-version "$(jq -r .metadata.version tree-sitter.json)"
       - name: Publish to npm
         run: npm publish ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-24.04
     environment:
       name: npm
-      url: https://www.npmjs.com/package/${{github.event.repository.name}}/
+      url: https://www.npmjs.com/package/tree-sitter-pwsh/
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -118,7 +118,6 @@ jobs:
         continue-on-error: true
         run: mv -v prebuilds/*.wasm .
       - name: Sync version from tree-sitter.json
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
-        run: npm version --no-git-tag-version "$(jq -r .metadata.version tree-sitter.json)"
+        run: npm version --no-git-tag-version --allow-same-version "$(jq -r .metadata.version tree-sitter.json)"
       - name: Publish to npm
         run: npm publish ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
+    paths:
+      - .github/workflows/publish_pypi.yml
 
 permissions:
   id-token: write
@@ -22,18 +25,6 @@ jobs:
           python-version: ${{vars.PYTHON_VERSION || '3.11'}}
       - name: Set up tree-sitter CLI
         uses: tree-sitter/setup-action/cli@v2
-      - name: Install dependencies
-        run: |-
-          if jq -e "$JQ_SCRIPT" package.json >/dev/null; then
-            npm i --ignore-scripts --omit peer --omit optional
-          fi
-        env:
-          JQ_SCRIPT: >-
-            .dependencies + .devDependencies |
-            with_entries(select(
-            (.key | startswith("tree-sitter-"))
-            and (.key != "tree-sitter-cli")
-            )) | length > 0
       - name: Regenerate parser
         shell: bash
         run: |
@@ -42,14 +33,12 @@ jobs:
             tree-sitter generate
             popd > /dev/null
           done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
-        env:
-          TREE_SITTER_ABI_VERSION: 15
       - name: Install dependencies
         run: pip install --upgrade pip build setuptools wheel
       - name: Build sources
         run: python -mbuild -n -s
       - name: Upload sources
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dist-sources
           path: dist/*.tar.gz
@@ -72,19 +61,6 @@ jobs:
         uses: actions/checkout@v6
       - name: Set up tree-sitter CLI
         uses: tree-sitter/setup-action/cli@v2
-      - name: Install dependencies
-        shell: bash
-        run: |-
-          if jq -e "$JQ_SCRIPT" package.json >/dev/null; then
-            npm i --ignore-scripts --omit peer --omit optional
-          fi
-        env:
-          JQ_SCRIPT: >-
-            .dependencies + .devDependencies |
-            with_entries(select(
-            (.key | startswith("tree-sitter-"))
-            and (.key != "tree-sitter-cli")
-            )) | length > 0
       - name: Regenerate parser
         shell: bash
         run: |
@@ -94,16 +70,14 @@ jobs:
             tree-sitter generate
             popd > /dev/null
           done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
-        env:
-          TREE_SITTER_ABI_VERSION: 15
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3
+        uses: pypa/cibuildwheel@v3.4
         with:
           output-dir: dist
         env:
           CIBW_ARCHS: native
       - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           path: dist/*.whl
           name: dist-wheels-${{matrix.os}}
@@ -114,11 +88,11 @@ jobs:
     needs: [build_sdist, build_wheels]
     runs-on: ubuntu-latest
     environment:
-      name: pypi
-      url: https://pypi.org/project/${{github.event.repository.name}}/
+      name: ${{ github.event_name == 'pull_request' && 'testpypi' || 'pypi' }}
+      url: ${{ github.event_name == 'pull_request' && format('https://test.pypi.org/project/{0}/', github.event.repository.name) || format('https://pypi.org/project/{0}/', github.event.repository.name) }}
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: dist
           pattern: dist-*
@@ -126,4 +100,14 @@ jobs:
       - name: Check build artifacts
         run: ls -l dist
       - name: Publish to PyPI
+        if: github.event_name != 'pull_request'
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+      - name: Publish to Test PyPI (dry run)
+        if: github.event_name == 'pull_request'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true
+          skip-existing: true

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.event_name == 'pull_request' && 'testpypi' || 'pypi' }}
-      url: ${{ github.event_name == 'pull_request' && format('https://test.pypi.org/project/{0}/', github.event.repository.name) || format('https://pypi.org/project/{0}/', github.event.repository.name) }}
+      url: ${{ github.event_name == 'pull_request' && 'https://test.pypi.org/project/tree-sitter-pwsh/' || 'https://pypi.org/project/tree-sitter-pwsh/' }}
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["setuptools>=62.4.0", "wheel"]
+requires = ["setuptools>=80"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "tree-sitter-pwsh"
 description = "PowerShell grammar for tree-sitter"
-version = "0.26.3"
+dynamic = ["version"]
 keywords = ["incremental", "parsing", "tree-sitter", "powershell", "pwsh"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
+import json
 from os import path
 from sysconfig import get_config_var
 
 from setuptools import Extension, find_packages, setup
+
+with open("tree-sitter.json") as f:
+    _metadata = json.load(f)["metadata"]
 from setuptools.command.build import build
 from setuptools.command.build_ext import build_ext
 from setuptools.command.egg_info import egg_info
@@ -45,6 +49,7 @@ class EggInfo(egg_info):
 
 
 setup(
+    version=_metadata["version"],
     packages=find_packages("bindings/python"),
     package_dir={"": "bindings/python"},
     package_data={

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -17,7 +17,7 @@
     }
   ],
   "metadata": {
-    "version": "0.26.3",
+    "version": "0.27.0",
     "license": "MIT",
     "description": "PowerShell grammar for tree-sitter",
     "authors": [


### PR DESCRIPTION
## Summary
- **npm/crates**: Sync version from `tree-sitter.json` at publish time (`npm version` / `yq` into `Cargo.toml`) so the single source of truth is always respected
- **npm**: Use latest `tree-sitter/setup-action/cli@v2` instead of `npm x -- tree-sitter` (which was locked to the 0.24.7 devDependency pinned for Go compatibility)
- **pypi**: Make Python version dynamic — `setup.py` reads from `tree-sitter.json`, `pyproject.toml` declares `dynamic = ["version"]`, bump `setuptools>=80`
- **All workflows**: Add PR trigger with dry-run support; remove unused jq dependency-check blocks and hardcoded `TREE_SITTER_ABI_VERSION` env
- **pypi**: Bump `cibuildwheel` v3.3→v3.4, `upload-artifact` v6→v7, `download-artifact` v7→v8; split publish into real PyPI vs Test PyPI

## Test plan
- [ ] Verify PR-triggered dry-runs pass on all three workflows
- [ ] Tag a test release and confirm npm/PyPI/crates.io publish succeeds with version from `tree-sitter.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD publishing workflows now support pull-request testing with dry-run publishing to crates, npm, and PyPI for safer validation before releases.
  * Package versions are centralized to a single source and synced into language-specific package metadata to avoid duplication.
  * Build-system and publishing tooling updated to newer action/tool versions and tightened build requirements for more consistent builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->