### PR TITLE
fix: make Package.swift fully declarative, add Swift CI

### DIFF
--- a/.github/workflows/swift-compat.yml
+++ b/.github/workflows/swift-compat.yml
@@ -1,0 +1,22 @@
+name: Swift Compatibility
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  swift-compat:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Build Swift package
+        run: swift build
+
+      - name: Run Swift tests
+        run: swift test

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ node_modules/
 
 # Swift artifacts
 .build/
+.swiftpm/
+Package.resolved
 
 # Go artifacts
 _obj/

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,6 @@
 // swift-tools-version:5.3
 
-import Foundation
 import PackageDescription
-
-var sources = ["src/parser.c"]
-if FileManager.default.fileExists(atPath: "src/scanner.c") {
-    sources.append("src/scanner.c")
-}
 
 let package = Package(
     name: "TreeSitterPowershell",
@@ -21,12 +15,52 @@ let package = Package(
             name: "TreeSitterPowershell",
             dependencies: [],
             path: ".",
-            sources: sources,
+            exclude: [
+                ".editorconfig",
+                ".envrc",
+                ".gitattributes",
+                ".github",
+                ".zed",
+                "binding.gyp",
+                "bindings/c",
+                "bindings/go",
+                "bindings/node",
+                "bindings/python",
+                "bindings/rust",
+                "Cargo.lock",
+                "Cargo.toml",
+                "CMakeLists.txt",
+                "eslint.config.mjs",
+                "flake.lock",
+                "flake.nix",
+                "go-compat",
+                "go.mod",
+                "go.sum",
+                "grammar.js",
+                "LICENSE",
+                "Makefile",
+                "node_types.go",
+                "package-lock.json",
+                "package.json",
+                "pyproject.toml",
+                "queries.go",
+                "queries_test.go",
+                "README.md",
+                "setup.py",
+                "src/grammar.json",
+                "src/node-types.json",
+                "test",
+                "tree-sitter.json",
+            ],
+            sources: [
+                "src/parser.c",
+                "src/scanner.c",
+            ],
             resources: [
-                .copy("queries")
+                .copy("queries"),
             ],
             publicHeadersPath: "bindings/swift",
-            cSettings: [.headerSearchPath("src")]
+            cSettings: [.headerSearchPath("src")],
         ),
         .testTarget(
             name: "TreeSitterPowershellTests",
@@ -34,8 +68,8 @@ let package = Package(
                 "SwiftTreeSitter",
                 "TreeSitterPowershell",
             ],
-            path: "bindings/swift/TreeSitterPowershellTests"
-        )
+            path: "bindings/swift/TreeSitterPowershellTests",
+        ),
     ],
     cLanguageStandard: .c11
 )


### PR DESCRIPTION
## Summary
- Replace runtime `Foundation`/`FileManager.fileExists` check with explicit `exclude` list and static `sources` in `Package.swift`
- The dynamic approach can fail in sandboxed Xcode package resolution and non-Darwin SPM environments
- Add `.swiftpm/` and `Package.resolved` to `.gitignore`
- Add Swift compatibility CI workflow (`swift build` + `swift test` on Ubuntu and macOS)

Mirror of wharflab/tree-sitter-batch#17

## Test plan
- [ ] Verify `swift build` succeeds (CI will validate on both platforms)
- [ ] Verify `swift test` loads the grammar successfully
- [ ] Verify adding as SPM dependency in an Xcode project resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)