### PR TITLE
chore: type-check grammar.js with tsc in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - grammar.js
       - eslint.config.mjs
+      - tsconfig.json
       - package.json
       - package-lock.json
       - .github/workflows/lint.yml
@@ -13,6 +14,7 @@ on:
     paths:
       - grammar.js
       - eslint.config.mjs
+      - tsconfig.json
       - package.json
       - package-lock.json
       - .github/workflows/lint.yml
@@ -32,3 +34,5 @@ jobs:
         run: npm ci
       - name: Run ESLint
         run: npm run lint
+      - name: Type-check grammar.js
+        run: npm run typecheck

--- a/grammar.js
+++ b/grammar.js
@@ -1,3 +1,6 @@
+/// <reference types="tree-sitter-cli/dsl"/>
+// @ts-check
+
 const PREC = {
   KEYWORD: 1,
   UNARY: 2,
@@ -1449,7 +1452,7 @@ function reservedWord(word) {
 /**
  * Create a reserved regex keyword
  *
- * @param {regex} regex
+ * @param {string} regex
  */
 function reserved(regex) {
   return prec(PREC.KEYWORD, new RegExp(regex));
@@ -1459,7 +1462,7 @@ function reserved(regex) {
  * A `for (...)` clause boundary between two present clauses.
  * Empty clauses still require a literal `;` to avoid newline/formatting ambiguity.
  *
- * @param {$} $
+ * @param {GrammarSymbols<string>} $
  */
 function forClauseSeparator($) {
   return choice(';', $._for_clause_break);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-pwsh",
-  "version": "0.26.3",
+  "version": "0.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-pwsh",
-      "version": "0.26.3",
+      "version": "0.33.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19,7 +19,8 @@
         "globals": "^17.5.0",
         "prebuildify": "^6.0.1",
         "tree-sitter-cli": "0.26.8",
-        "tree-sitter-go-types": "^0.1.0"
+        "tree-sitter-go-types": "^0.1.0",
+        "typescript": "^6.0.3"
       },
       "peerDependencies": {
         "tree-sitter": "^0.25.0"
@@ -1388,6 +1389,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "globals": "^17.5.0",
     "prebuildify": "^6.0.1",
     "tree-sitter-cli": "0.26.8",
-    "tree-sitter-go-types": "^0.1.0"
+    "tree-sitter-go-types": "^0.1.0",
+    "typescript": "^6.0.3"
   },
   "overrides": {
     "eslint-plugin-jsdoc": "^62.9.0"
@@ -56,6 +57,7 @@
     "start": "tree-sitter playground",
     "generate": "tree-sitter generate --abi 14 && tree-sitter-go-types",
     "lint": "eslint grammar.js",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "node --test bindings/node/*_test.js"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": true,
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "types": ["tree-sitter-cli/dsl"]
+  },
+  "include": ["grammar.js"]
+}


### PR DESCRIPTION
## Summary
- Add `/// <reference types="tree-sitter-cli/dsl"/>` + `// @ts-check` to `grammar.js` (pattern from [kristoff-it/ziggy](https://github.com/kristoff-it/ziggy/blob/852053b09a5f8f5b79ca880f86ea77fc7da3dd6c/tree-sitter-ziggy/grammar.js#L137)), so editors and `tsc` validate DSL usage against the bundled types.
- Add a minimal `tsconfig.json` (`allowJs`/`checkJs`/`noEmit`/`strict`, `types: ["tree-sitter-cli/dsl"]`, includes only `grammar.js`) and a `npm run typecheck` script.
- Extend the Lint workflow to run `npm run typecheck` after ESLint, and add `tsconfig.json` to its path filters.
- Fix two JSDoc `@param` types the check flagged: `{regex}` → `{string}` on `reserved()`, `{$}` → `{GrammarSymbols<string>}` on `forClauseSeparator()`. No runtime behavior change — `src/parser.c` is unaffected.

Note: the pragma uses `// @ts-check` (with a space) rather than ziggy's `//@ts-check` to satisfy ESLint's `spaced-comment` rule without an inline disable. Both forms are equivalent to TypeScript.

## Test plan
- [x] `npm run typecheck` passes locally (exit 0)
- [x] `npm run lint` still passes locally
- [ ] Lint workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)