### PR TITLE
[codex] Fix nested backtick continuations in pipelines

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -90,6 +90,28 @@ static bool is_inline_trivia(int32_t lookahead)
     }
 }
 
+static bool skip_line_continuation(TSLexer *lexer)
+{
+    if (lexer->lookahead != '`') {
+        return false;
+    }
+
+    skip(lexer);
+    if (lexer->lookahead == '\r') {
+        skip(lexer);
+        if (lexer->lookahead == '\n') {
+            skip(lexer);
+        }
+        return true;
+    }
+    if (lexer->lookahead == '\n') {
+        skip(lexer);
+        return true;
+    }
+
+    return false;
+}
+
 static void skip_line_comment(TSLexer *lexer)
 {
     skip(lexer);
@@ -157,6 +179,9 @@ static bool scan_statement_boundary(TSLexer *lexer, const bool *valid_symbols)
         }
         if (is_inline_trivia(lexer->lookahead)) {
             skip(lexer);
+            continue;
+        }
+        if (skip_line_continuation(lexer)) {
             continue;
         }
         // Comments (line `#...` and block `<# ... #>`) are extras to PowerShell

--- a/test/corpus/regressions.txt
+++ b/test/corpus/regressions.txt
@@ -204,7 +204,6 @@ git --untracked-files=normal
 
 ===
 Nested backtick line continuations inside pipeline
-:skip
 ; source: rhysd/ghci-color/ghci-color.ps1
 ===
 
@@ -215,7 +214,51 @@ gci | `
 
 ---
 
-(program)
+(program
+  (statement_list
+    (pipeline
+      (pipeline_chain
+        (command
+          (command_name)
+          (command_elements
+            (command_argument_sep)))
+        (command
+          (command_name)
+          (command_elements
+            (command_argument_sep)
+            (array_literal_expression
+              (unary_expression
+                (script_block_expression
+                  (script_block
+                    (script_block_body
+                      (statement_list
+                        (pipeline
+                          (pipeline_chain
+                            (ternary_expression
+                              (null_coalesce_expression
+                                (logical_expression
+                                  (bitwise_expression
+                                    (comparison_expression
+                                      (comparison_expression
+                                        (additive_expression
+                                          (multiplicative_expression
+                                            (format_expression
+                                              (range_expression
+                                                (array_literal_expression
+                                                  (unary_expression
+                                                    (variable))))))))
+                                      (comparison_operator)
+                                      (additive_expression
+                                        (multiplicative_expression
+                                          (format_expression
+                                            (range_expression
+                                              (array_literal_expression
+                                                (unary_expression
+                                                  (string_literal
+                                                    (verbatim_string_characters)))
+                                                (unary_expression
+                                                  (string_literal
+                                                    (verbatim_string_characters)))))))))))))))))))))))))))
 
 ===
 Expandable bareword path with backslash and glob as comma-separated args


### PR DESCRIPTION
## Summary

- Teach the external statement-boundary scanner to skip PowerShell backtick-newline continuations while looking for the real statement boundary.
- Enable the issue 29 regression covering a continued pipeline with a nested scriptblock continuation.

## Root Cause

`_statement_boundary` handled newlines, inline trivia, and comments while scanning ahead, but did not skip the backtick-newline continuation that `extras` accepts elsewhere. A trailing continuation inside a nested scriptblock could therefore prevent the scanner from recognizing the `}` boundary and push the parse into recovery.

Fixes #29.

## Validation

- `tree-sitter test`
- `go test ./...`