### PR TITLE
Fix native command equals argument regression

### DIFF
--- a/test/corpus/regressions.txt
+++ b/test/corpus/regressions.txt
@@ -298,7 +298,6 @@ Add-Type -AssemblyName PresentationCore , PresentationFramework , System.Windows
 
 ===
 Native command argument containing equals sign
-:skip
 ; source: silverqx/TinyORM/tools/deploy.ps1
 ===
 
@@ -306,7 +305,15 @@ git --untracked-files=normal
 
 ---
 
-(program)
+(program
+  (statement_list
+    (pipeline
+      (pipeline_chain
+        (command
+          (command_name)
+          (command_elements
+            (command_argument_sep)
+            (command_parameter)))))))
 
 ===
 Nested backtick line continuations inside pipeline


### PR DESCRIPTION
## Summary

- Enable the existing regression for native command long arguments using `--name=value` syntax.
- Record the expected parse tree for `git --untracked-files=normal` so the corpus gate covers issue #36.

Fixes #36.

## Validation

- `tree-sitter test`
- `go test ./...`
- `git diff --check`