### PR TITLE
build: drop conditional source includes for hermetic builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter-powershell
-        VERSION "0.38.0"
+        VERSION "0.38.1"
         DESCRIPTION ""
         HOMEPAGE_URL "https://github.com/airbus-cert/tree-sitter-powershell"
         LANGUAGES C)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,7 @@ add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                    COMMENT "Generating parser.c")
 
-add_library(tree-sitter-powershell src/parser.c)
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/scanner.c)
-  target_sources(tree-sitter-powershell PRIVATE src/scanner.c)
-endif()
+add_library(tree-sitter-powershell src/parser.c src/scanner.c)
 target_include_directories(tree-sitter-powershell
                            PRIVATE src
                            INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/bindings/c>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-pwsh"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-pwsh"
 description = "PowerShell grammar for tree-sitter"
-version = "0.38.0"
+version = "0.38.1"
 authors = ["Wharflab"]
 license = "MIT"
 readme = "README.md"

--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,7 @@ else
 	cd '$(DESTDIR)$(LIBDIR)' && ln -sf lib$(LANGUAGE_NAME).$(SOEXTVER) lib$(LANGUAGE_NAME).$(SOEXTVER_MAJOR)
 	cd '$(DESTDIR)$(LIBDIR)' && ln -sf lib$(LANGUAGE_NAME).$(SOEXTVER_MAJOR) lib$(LANGUAGE_NAME).$(SOEXT)
 endif
-ifneq ($(wildcard queries/*.scm),)
 	install -m644 queries/*.scm '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/powershell
-endif
 
 uninstall:
 	$(RM) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).a \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 LANGUAGE_NAME := tree-sitter-powershell
 HOMEPAGE_URL := https://github.com/airbus-cert/tree-sitter-powershell
-VERSION := 0.38.0
+VERSION := 0.38.1
 
 # repository
 SRC_DIR := src

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,14 +11,9 @@
       "sources": [
         "bindings/node/binding.cc",
         "src/parser.c",
+        "src/scanner.c",
       ],
-      "variables": {
-        "has_scanner": "<!(node -p \"fs.existsSync('src/scanner.c')\")"
-      },
       "conditions": [
-        ["has_scanner=='true'", {
-          "sources+": ["src/scanner.c"],
-        }],
         ["OS!='win'", {
           "cflags_c": [
             "-std=c11",

--- a/bindings/go/binding.go
+++ b/bindings/go/binding.go
@@ -2,9 +2,7 @@ package tree_sitter_powershell
 
 // #cgo CFLAGS: -std=c11 -fPIC -I${SRCDIR}/../../src
 // #include "../../src/parser.c"
-// #if __has_include("../../src/scanner.c")
 // #include "../../src/scanner.c"
-// #endif
 import "C"
 
 import "unsafe"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -30,27 +30,8 @@ fn main() {
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
     let scanner_path = src_dir.join("scanner.c");
-    if scanner_path.exists() {
-        c_config.file(&scanner_path);
-        println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    }
+    c_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
 
     c_config.compile("tree-sitter-powershell");
-
-    println!("cargo:rustc-check-cfg=cfg(with_highlights_query)");
-    if !"queries/highlights.scm".is_empty() && std::path::Path::new("queries/highlights.scm").exists() {
-        println!("cargo:rustc-cfg=with_highlights_query");
-    }
-    println!("cargo:rustc-check-cfg=cfg(with_injections_query)");
-    if !"queries/injections.scm".is_empty() && std::path::Path::new("queries/injections.scm").exists() {
-        println!("cargo:rustc-cfg=with_injections_query");
-    }
-    println!("cargo:rustc-check-cfg=cfg(with_locals_query)");
-    if !"queries/locals.scm".is_empty() && std::path::Path::new("queries/locals.scm").exists() {
-        println!("cargo:rustc-cfg=with_locals_query");
-    }
-    println!("cargo:rustc-check-cfg=cfg(with_tags_query)");
-    if !"queries/tags.scm".is_empty() && std::path::Path::new("queries/tags.scm").exists() {
-        println!("cargo:rustc-cfg=with_tags_query");
-    }
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -32,21 +32,8 @@ pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_power
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers/6-static-node-types
 pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
-#[cfg(with_highlights_query)]
 /// The syntax highlighting query for this grammar.
 pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
-
-#[cfg(with_injections_query)]
-/// The language injection query for this grammar.
-pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
-
-#[cfg(with_locals_query)]
-/// The local variable query for this grammar.
-pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
-
-#[cfg(with_tags_query)]
-/// The symbol tagging query for this grammar.
-pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-pwsh",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "PowerShell grammar for tree-sitter",
   "type": "module",
   "repository": {

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,8 @@ from wheel.bdist_wheel import bdist_wheel
 
 class Build(build):
     def run(self):
-        if path.isdir("queries"):
-            dest = path.join(self.build_lib, "tree_sitter_pwsh", "queries")
-            self.copy_tree("queries", dest)
+        dest = path.join(self.build_lib, "tree_sitter_pwsh", "queries")
+        self.copy_tree("queries", dest)
         super().run()
 
 
@@ -26,8 +25,6 @@ class BuildExt(build_ext):
             ext.extra_compile_args = ["-std=c11", "-fvisibility=hidden"]
         else:
             ext.extra_compile_args = ["/std:c11", "/utf-8"]
-        if path.exists("src/scanner.c"):
-            ext.sources.append("src/scanner.c")
         if ext.py_limited_api:
             ext.define_macros.append(("Py_LIMITED_API", "0x030A0000"))
         super().build_extension(ext)
@@ -63,6 +60,7 @@ setup(
             sources=[
                 "bindings/python/tree_sitter_pwsh/binding.c",
                 "src/parser.c",
+                "src/scanner.c",
             ],
             define_macros=[
                 ("PY_SSIZE_T_CLEAN", None),

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -20,7 +20,7 @@
     }
   ],
   "metadata": {
-    "version": "0.38.0",
+    "version": "0.38.1",
     "license": "MIT",
     "description": "PowerShell grammar for tree-sitter",
     "authors": [


### PR DESCRIPTION
## Summary
- Removed `#if __has_include`, `if(EXISTS ...)`, `path.exists(...)`, `fs.existsSync(...)`, and `if scanner_path.exists()` guards around `src/scanner.c` across the Go, Rust, Node, Python, CMake, and Makefile build inputs. These checks always evaluate true (the file is committed), but they break hermetic build systems like Bazel where shell-level glob/exists checks don't see the sandboxed source tree.
- Removed matching `path.isdir("queries")` / `wildcard queries/*.scm` guards around the `queries/` install steps in `setup.py` and `Makefile`.
- Cleaned up the Rust `with_*_query` cfg machinery in `bindings/rust/build.rs` + `bindings/rust/lib.rs`. Only `highlights.scm` exists in this repo, so the cfg gate guarded `include_str!` calls for `injections.scm`/`locals.scm`/`tags.scm` that would never resolve. `HIGHLIGHTS_QUERY` is now unconditional.
- Bumped patch version to **0.38.1** via `tree-sitter version --bump patch` (touches `tree-sitter.json`, `CMakeLists.txt`, `Cargo.toml`, `Cargo.lock`, `package.json`, `Makefile`).

## Test plan
- [ ] `tree-sitter test` passes
- [ ] `go test ./...` passes (`go-compat` smoke test)
- [ ] `cargo build` and `cargo test` pass with the new build.rs / lib.rs
- [ ] `npm install` (node-gyp) succeeds with the simplified `binding.gyp`
- [ ] `python -m pip install .` succeeds with the unconditional `setup.py` sources
- [ ] `cmake --build` and `make` produce a working library
- [ ] Verify CI `parse-fixtures`, `parse-sample`, and `go-compat` jobs are green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.38.1
  * Updated build configurations to ensure consistent compilation across CMake, Cargo, Makefile, Node.js, Python, Go, and Rust bindings
  * Simplified Rust bindings API by removing conditional query constant exports

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wharflab/tree-sitter-powershell/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->